### PR TITLE
handle mediumtext type used in comments

### DIFF
--- a/inc/object.class.php
+++ b/inc/object.class.php
@@ -752,7 +752,8 @@ class PluginGenericobjectObject extends CommonDBTM
 
                 case "longtext":
                 case "text":
-                    echo "<textarea cols='40' rows='4' name='" . $name . "'>" . $value .
+                case "mediumtext":
+                    echo "<textarea cols='40' rows='4' class='form-control' name='" . $name . "'>" . $value .
                      "</textarea>";
                     break;
 
@@ -1035,6 +1036,7 @@ class PluginGenericobjectObject extends CommonDBTM
                     break;
                 case "text":
                 case "longtext":
+                case "mediumtext":
                     $option['datatype'] = 'text';
                     if ($item->canUsePluginDataInjection()) {
                        //Datainjection specific


### PR DESCRIPTION
Comments are not correctly displayed in generic objects:
- Comments use mediumtext type
- Add 'form-control' class to get the correct style for comments

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x ] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes #401
- Here is a brief description of what this PR does

## Screenshots (if appropriate):
without fix:
![image](https://github.com/user-attachments/assets/f5ec1892-d207-4ff7-9c8c-85198b8bbb85)
with fix:
![image](https://github.com/user-attachments/assets/6e451e0d-8f92-42e0-99f4-db72cacfc4de)

